### PR TITLE
Windows-Specific Runtime Error Fix + Build Errors

### DIFF
--- a/.idea/gradle.xml
+++ b/.idea/gradle.xml
@@ -12,7 +12,6 @@
             <option value="$PROJECT_DIR$" />
           </set>
         </option>
-        <option name="useQualifiedModuleNames" value="true" />
       </GradleProjectSettings>
     </option>
   </component>

--- a/build.gradle
+++ b/build.gradle
@@ -70,7 +70,7 @@ configurations {
 }
 
 dependencies {
-    implementation ('com.github.spotbugs:spotbugs:4.0.3') {
+    implementation ('com.github.spotbugs:spotbugs:4.1.3') {
         exclude group: 'xml-apis', module: 'xml-apis'
     }
     implementation 'org.jsoup:jsoup:1.8.3'

--- a/gradle.properties
+++ b/gradle.properties
@@ -18,5 +18,5 @@
 # If not, see <http://www.gnu.org/licenses/>.
 #
 
-version=2.5.1
+version=2.6.0
 ijVersion=2021.1

--- a/gradle.properties
+++ b/gradle.properties
@@ -19,4 +19,4 @@
 #
 
 version=2.5.1
-ijVersion=2019.3
+ijVersion=2021.1

--- a/src/main/java/com/reshiftsecurity/plugins/intellij/actions/AnalyzeScopeFiles.java
+++ b/src/main/java/com/reshiftsecurity/plugins/intellij/actions/AnalyzeScopeFiles.java
@@ -274,11 +274,6 @@ public final class AnalyzeScopeFiles extends AbstractAnalyzeAction {
 	}
 
 	private static String getModuleNameInReadAction(@NotNull final Module module) {
-//		return new ReadAction<String>() {
-//			protected void run(@NotNull Result<String> result) throws Throwable {
-//				result.setResult(module.getName());
-//			}
-//		}.execute().getResultObject();
 
 		return module.getName(); //HACK: Something about run is deprecated, unsure of how read actions work here, or why they're necessary
 		//According to ReadAction, it wants us to use public static <E extends Throwable> void run(@NotNull ThrowableRunnable<E> action) throws E

--- a/src/main/java/com/reshiftsecurity/plugins/intellij/actions/AnalyzeScopeFiles.java
+++ b/src/main/java/com/reshiftsecurity/plugins/intellij/actions/AnalyzeScopeFiles.java
@@ -29,6 +29,7 @@ import com.intellij.openapi.actionSystem.LangDataKeys;
 import com.intellij.openapi.actionSystem.PlatformDataKeys;
 import com.intellij.openapi.application.ReadAction;
 import com.intellij.openapi.application.Result;
+import com.intellij.openapi.application.RunResult;
 import com.intellij.openapi.compiler.CompileScope;
 import com.intellij.openapi.compiler.CompilerManager;
 import com.intellij.openapi.fileEditor.FileDocumentManager;
@@ -39,6 +40,7 @@ import com.intellij.openapi.progress.ProgressIndicator;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.roots.ProjectFileIndex;
 import com.intellij.openapi.roots.ProjectRootManager;
+import com.intellij.openapi.util.ThrowableComputable;
 import com.intellij.openapi.vfs.JarFileSystem;
 import com.intellij.openapi.vfs.VfsUtilCore;
 import com.intellij.openapi.vfs.VirtualFile;
@@ -50,6 +52,7 @@ import com.intellij.psi.PsiFile;
 import com.intellij.psi.PsiManager;
 import com.intellij.psi.PsiRecursiveElementVisitor;
 import com.intellij.util.Consumer;
+import com.intellij.util.ThrowableRunnable;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.jetbrains.annotations.NonNls;
 import org.jetbrains.annotations.NotNull;
@@ -271,10 +274,16 @@ public final class AnalyzeScopeFiles extends AbstractAnalyzeAction {
 	}
 
 	private static String getModuleNameInReadAction(@NotNull final Module module) {
-		return new ReadAction<String>() {
-			protected void run(@NotNull final Result<String> result) throws Throwable {
-				result.setResult(module.getName());
-			}
-		}.execute().getResultObject();
+//		return new ReadAction<String>() {
+//			protected void run(@NotNull Result<String> result) throws Throwable {
+//				result.setResult(module.getName());
+//			}
+//		}.execute().getResultObject();
+
+		return module.getName(); //HACK: Something about run is deprecated, unsure of how read actions work here, or why they're necessary
+		//According to ReadAction, it wants us to use public static <E extends Throwable> void run(@NotNull ThrowableRunnable<E> action) throws E
+		//That calls public static <T, E extends Throwable> T compute(@NotNull ThrowableComputable<T, E> action) throws E
+		//And then *that* calls return ApplicationManager.getApplication().runReadAction(action);
+		//Far as I can see, all the commented code above is doing is returning the module's name
 	}
 }

--- a/src/main/java/com/reshiftsecurity/plugins/intellij/common/util/SourceCodeUtil.java
+++ b/src/main/java/com/reshiftsecurity/plugins/intellij/common/util/SourceCodeUtil.java
@@ -71,13 +71,11 @@ public class SourceCodeUtil {
 
     public static Path getPathFromSourceLineAnnotation(SourceLineAnnotation annotation) {
         String packageName = annotation.getPackageName();
-        String packagePath;
-        if(File.separator.equals("\\")){ //Edge case needed here due to how backslashes operate and the fact that Windows uses them
-            packagePath = packageName.trim().replaceAll("[.]", "\\\\");
+        String separator = File.separator;
+        if(separator.equals("\\")){ //Edge case needed here due to how backslashes operate and the fact that Windows uses them
+            separator = "\\\\";
         }
-        else{
-            packagePath = packageName.trim().replaceAll("[.]", File.separator);
-        }
+        String packagePath = packageName.trim().replaceAll("[.]", separator);
         String fileName = annotation.getSourceFile();
         return Paths.get(packagePath, fileName);
     }

--- a/src/main/java/com/reshiftsecurity/plugins/intellij/common/util/SourceCodeUtil.java
+++ b/src/main/java/com/reshiftsecurity/plugins/intellij/common/util/SourceCodeUtil.java
@@ -23,7 +23,6 @@ package com.reshiftsecurity.plugins.intellij.common.util;
 import com.intellij.openapi.vfs.VirtualFile;
 import edu.umd.cs.findbugs.SourceLineAnnotation;
 import org.apache.commons.lang.StringUtils;
-import org.mozilla.javascript.tools.shell.Environment;
 
 import java.io.File;
 import java.nio.file.Files;
@@ -72,7 +71,13 @@ public class SourceCodeUtil {
 
     public static Path getPathFromSourceLineAnnotation(SourceLineAnnotation annotation) {
         String packageName = annotation.getPackageName();
-        String packagePath = packageName.trim().replaceAll("[.]", File.separator);
+        String packagePath;
+        if(File.separator.equals("\\")){ //Edge case needed here due to how backslashes operate and the fact that Windows uses them
+            packagePath = packageName.trim().replaceAll("[.]", "\\\\");
+        }
+        else{
+            packagePath = packageName.trim().replaceAll("[.]", File.separator);
+        }
         String fileName = annotation.getSourceFile();
         return Paths.get(packagePath, fileName);
     }

--- a/src/main/java/com/reshiftsecurity/plugins/intellij/core/ErrorReportSubmitterImpl.java
+++ b/src/main/java/com/reshiftsecurity/plugins/intellij/core/ErrorReportSubmitterImpl.java
@@ -56,7 +56,7 @@ public final class ErrorReportSubmitterImpl extends ErrorReportSubmitter {
 	}
 
 	@Override
-	public boolean submit(@NotNull IdeaLoggingEvent[] events, @Nullable String additionalInfo, @NotNull Component parentComponent, @NotNull Consumer<SubmittedReportInfo> consumer) {
+	public boolean submit(IdeaLoggingEvent @NotNull [] events, @Nullable String additionalInfo, @NotNull Component parentComponent, @NotNull Consumer<? super SubmittedReportInfo> consumer) { //It compiles, ignore the squiggly.
 
 		final AtomicReference<String> latestVersionRef = New.atomicRef(null);
 		new Task.Modal(null, ResourcesLoader.getString("error.submitReport.checkVersion"), false) {

--- a/src/main/java/com/reshiftsecurity/plugins/intellij/gui/editor/BugsLineMarkerProvider.java
+++ b/src/main/java/com/reshiftsecurity/plugins/intellij/gui/editor/BugsLineMarkerProvider.java
@@ -48,9 +48,9 @@ import com.reshiftsecurity.plugins.intellij.gui.toolwindow.view.ToolWindowPanel;
 import com.reshiftsecurity.plugins.intellij.intentions.ClearBugIntentionAction;
 import com.reshiftsecurity.plugins.intellij.intentions.SuppressReportBugIntentionAction;
 
+import javax.swing.*;
 import java.awt.event.MouseEvent;
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.regex.Pattern;
@@ -102,7 +102,8 @@ public final class BugsLineMarkerProvider implements LineMarkerProvider {
 			}
 			if (!matchingDescriptors.isEmpty()) {
 				final GutterIconNavigationHandler<PsiElement> navHandler = new BugGutterIconNavigationHandler(psiElement, matchingDescriptors);
-				return new LineMarkerInfo<PsiElement>(psiElement, psiElement.getTextRange(), GuiUtil.getTinyIcon(matchingDescriptors.get(0)), 4, new TooltipProvider(matchingDescriptors), navHandler, GutterIconRenderer.Alignment.LEFT);
+				Icon icon = GuiUtil.getTinyIcon(matchingDescriptors.get(0));
+				return new LineMarkerInfo<PsiElement>(psiElement, psiElement.getTextRange(), icon, 4, new TooltipProvider(matchingDescriptors), navHandler, GutterIconRenderer.Alignment.LEFT);
 			}
 		}
 

--- a/src/main/java/com/reshiftsecurity/plugins/intellij/gui/settings/AdvancedSettingsAction.java
+++ b/src/main/java/com/reshiftsecurity/plugins/intellij/gui/settings/AdvancedSettingsAction.java
@@ -158,13 +158,13 @@ final class AdvancedSettingsAction extends DefaultActionGroup {
 
 		@Override
 		public void actionPerformed(@NotNull final AnActionEvent e) {
-
+			VirtualFile placeholder = null; //Save function ambiguous when passing null directly, have to use either Path or VirtualFile
 			final VirtualFileWrapper wrapper = FileChooserFactory.getInstance().createSaveFileDialog(
 					new FileSaverDescriptor(
 							ResourcesLoader.getString("settings.export.title"),
 							ResourcesLoader.getString("settings.export.description"),
 							XmlFileType.DEFAULT_EXTENSION
-					), settingsPane).save(null, "Reshift");
+					), settingsPane).save(placeholder, "Reshift");
 			if (wrapper == null) {
 				return;
 			}

--- a/src/main/java/com/reshiftsecurity/plugins/intellij/gui/settings/FilterTab.java
+++ b/src/main/java/com/reshiftsecurity/plugins/intellij/gui/settings/FilterTab.java
@@ -23,8 +23,10 @@ import com.intellij.ide.highlighter.XmlFileType;
 import com.intellij.openapi.fileChooser.FileChooserFactory;
 import com.intellij.openapi.fileChooser.FileSaverDescriptor;
 import com.intellij.openapi.options.ConfigurationException;
+import com.intellij.openapi.project.Project;
 import com.intellij.openapi.util.io.FileUtil;
 import com.intellij.openapi.util.text.StringUtil;
+import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.openapi.vfs.VirtualFileWrapper;
 import org.jetbrains.annotations.NotNull;
 import com.reshiftsecurity.plugins.intellij.common.util.ErrorUtil;
@@ -89,12 +91,13 @@ final class FilterTab extends JPanel implements SettingsOwner<AbstractSettings> 
 	}
 
 	void addRFilerFilter() {
+		VirtualFile placeholder = null; //Save function ambiguous when passing null directly, have to use either Path or VirtualFile
 		final VirtualFileWrapper wrapper = FileChooserFactory.getInstance().createSaveFileDialog(
 				new FileSaverDescriptor(
 						StringUtil.capitalizeWords(ResourcesLoader.getString("filter.rFile.save.title"), true),
 						ResourcesLoader.getString("filter.rFile.save.text"),
 						XmlFileType.DEFAULT_EXTENSION
-				), this).save(null, "findbugs-android-exclude");
+				), this).save(placeholder, "findbugs-android-exclude");
 		if (wrapper == null) {
 			return;
 		}

--- a/src/main/java/com/reshiftsecurity/plugins/intellij/resources/ResourcesLoader.java
+++ b/src/main/java/com/reshiftsecurity/plugins/intellij/resources/ResourcesLoader.java
@@ -22,6 +22,7 @@ package com.reshiftsecurity.plugins.intellij.resources;
 import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.util.IconLoader;
 import com.intellij.util.containers.ContainerUtil;
+import icons.PluginIcons;
 import org.jetbrains.annotations.Nls;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -134,7 +135,7 @@ public final class ResourcesLoader {
 
 	@NotNull
 	public static Icon loadIcon(final String filename) {
-		return IconLoader.getIcon(ICON_RESOURCES_PKG + '/' + filename);
+		return IconLoader.getIcon(ICON_RESOURCES_PKG + '/' + filename, PluginIcons.class);
 	}
 
 

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -19,6 +19,7 @@
   -->
 
 <idea-plugin url="https://reshiftsecurity.com">
+    <idea-version since-build="211"/>
     <name>Reshift Security</name>
     <description>
         <![CDATA[
@@ -46,6 +47,11 @@
     </description>
     <change-notes>
         <![CDATA[<html>
+        <h3>2.6.0</h3>
+        <ul>
+            <li>Support for 2021.1</li>
+            <li>Windows environment bugfix for XXE findings</li>
+        </ul>
         <h3>2.5.1</h3>
         <ul>
             <li>Fixed analytics settings apply/save</li>


### PR DESCRIPTION
- Updated dependencies in Gradle
- Updated Intellij version to 2021.1
- Updated AnalyzeScopeFiles to shortcut module name retrieval (further analysis possibly required, involves ReadActions)
- Updated SourceCodeUtil to handle case with Windows file separators (backslashes)
- Fixed compilation ambiguity errors across remaining classes