### PR TITLE
Reporter service exception

### DIFF
--- a/.idea/libraries-with-intellij-classes.xml
+++ b/.idea/libraries-with-intellij-classes.xml
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="libraries-with-intellij-classes">
+    <option name="intellijApiContainingLibraries">
+      <list>
+        <LibraryCoordinatesState>
+          <option name="artifactId" value="ideaIU" />
+          <option name="groupId" value="com.jetbrains.intellij.idea" />
+        </LibraryCoordinatesState>
+        <LibraryCoordinatesState>
+          <option name="artifactId" value="ideaIU" />
+          <option name="groupId" value="com.jetbrains" />
+        </LibraryCoordinatesState>
+        <LibraryCoordinatesState>
+          <option name="artifactId" value="ideaIC" />
+          <option name="groupId" value="com.jetbrains.intellij.idea" />
+        </LibraryCoordinatesState>
+        <LibraryCoordinatesState>
+          <option name="artifactId" value="ideaIC" />
+          <option name="groupId" value="com.jetbrains" />
+        </LibraryCoordinatesState>
+        <LibraryCoordinatesState>
+          <option name="artifactId" value="pycharmPY" />
+          <option name="groupId" value="com.jetbrains.intellij.pycharm" />
+        </LibraryCoordinatesState>
+        <LibraryCoordinatesState>
+          <option name="artifactId" value="pycharmPY" />
+          <option name="groupId" value="com.jetbrains" />
+        </LibraryCoordinatesState>
+        <LibraryCoordinatesState>
+          <option name="artifactId" value="pycharmPC" />
+          <option name="groupId" value="com.jetbrains.intellij.pycharm" />
+        </LibraryCoordinatesState>
+        <LibraryCoordinatesState>
+          <option name="artifactId" value="pycharmPC" />
+          <option name="groupId" value="com.jetbrains" />
+        </LibraryCoordinatesState>
+        <LibraryCoordinatesState>
+          <option name="artifactId" value="clion" />
+          <option name="groupId" value="com.jetbrains.intellij.clion" />
+        </LibraryCoordinatesState>
+        <LibraryCoordinatesState>
+          <option name="artifactId" value="clion" />
+          <option name="groupId" value="com.jetbrains" />
+        </LibraryCoordinatesState>
+        <LibraryCoordinatesState>
+          <option name="artifactId" value="riderRD" />
+          <option name="groupId" value="com.jetbrains.intellij.rider" />
+        </LibraryCoordinatesState>
+        <LibraryCoordinatesState>
+          <option name="artifactId" value="riderRD" />
+          <option name="groupId" value="com.jetbrains" />
+        </LibraryCoordinatesState>
+        <LibraryCoordinatesState>
+          <option name="artifactId" value="goland" />
+          <option name="groupId" value="com.jetbrains.intellij.goland" />
+        </LibraryCoordinatesState>
+        <LibraryCoordinatesState>
+          <option name="artifactId" value="goland" />
+          <option name="groupId" value="com.jetbrains" />
+        </LibraryCoordinatesState>
+      </list>
+    </option>
+  </component>
+</project>

--- a/.idea/runConfigurations.xml
+++ b/.idea/runConfigurations.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="RunConfigurationProducerService">
+    <option name="ignoredProducers">
+      <set>
+        <option value="com.android.tools.idea.compose.preview.runconfiguration.ComposePreviewRunConfigurationProducer" />
+      </set>
+    </option>
+  </component>
+</project>

--- a/gradle.properties
+++ b/gradle.properties
@@ -18,5 +18,5 @@
 # If not, see <http://www.gnu.org/licenses/>.
 #
 
-version=2.6.0
+version=2.6.1
 ijVersion=2021.1

--- a/src/main/java/com/reshiftsecurity/plugins/intellij/core/SecurityReportService.java
+++ b/src/main/java/com/reshiftsecurity/plugins/intellij/core/SecurityReportService.java
@@ -152,7 +152,7 @@ public class SecurityReportService implements PersistentStateComponent<SecurityR
             issue.categoryName = bug.getType();
             issue.classFQN = mainSourceLineAnnotation.getClassName();
             issue.lineNumber = mainSourceLineAnnotation.getStartLine();
-            issue.methodFullSignature = bug.getPrimaryMethod().getFullMethod(null);
+            issue.methodFullSignature = (bug.getPrimaryMethod() != null ? bug.getPrimaryMethod().getFullMethod(null) : "");
             issue.code = SourceCodeUtil.getTrimmedSourceLine(projectSourceFiles, mainSourceLineAnnotation);
             issue.cweId = bug.getCWEid();
             issue.issueHash = HashUtil.hashThis(String.format("%s|%s", issue.cweId, bug.getInstanceKey()));

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -47,6 +47,10 @@
     </description>
     <change-notes>
         <![CDATA[<html>
+        <h3>2.6.1</h3>
+        <ul>
+            <li>Minor exception fix</li>
+        </ul>
         <h3>2.6.0</h3>
         <ul>
             <li>Support for 2021.1</li>


### PR DESCRIPTION
Changes:
- Some users reported a java.lang.NullPointerException at `com.reshiftsecurity.plugins.intellij.core.SecurityReportService.addBugCollection(SecurityReportService.java:155)`
- Exception seems to stem from `bug.getPrimaryMethod()...`. So added null pointer handling for now.
- Also committed some `.idea` files for convenience in importing the project (for dev environment).
- Updated version number and release notes.