### PR TITLE
Class cast issue fix (v2.6.2 bump)

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -18,5 +18,5 @@
 # If not, see <http://www.gnu.org/licenses/>.
 #
 
-version=2.6.1
-ijVersion=2021.1
+version=2.6.2
+ijVersion=2021.2

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -47,6 +47,11 @@
     </description>
     <change-notes>
         <![CDATA[<html>
+        <h3>2.6.2</h3>
+        <ul>
+            <li>Class cast exception fix (SmartList to ArrayList)</li>
+            <li>Deprecation notice fix</li>
+        </ul>
         <h3>2.6.1</h3>
         <ul>
             <li>Minor exception fix</li>


### PR DESCRIPTION
- Exception occured for users of intellij 2021.1/2 where Security Service could not convert SmartList to ArrayList as part of report persistance process.
- Also fixed a deprecation notice with "getService()" method in the same class.